### PR TITLE
Pour réparer la mise en page cassée de profil.html

### DIFF
--- a/profil.html
+++ b/profil.html
@@ -24,11 +24,10 @@
 
 <INCLURE{fond=inc/entete}>
 
-
-	[(#ID_AUTEUR|microcache{noisettes/entete_auteur})]
-
 <div id="principale"><div>
 
+		[(#ID_AUTEUR|microcache{noisettes/entete_auteur})]
+		
 		[(#FORMULAIRE_PROFIL)]
 		
 


### PR DESCRIPTION
`[(#ID_AUTEUR|microcache{noisettes/entete_auteur})]` n'était pas dans `#principale`, ce qui cassait la mise en page.
