### PR TITLE
Cacher la fin des textes très long dans les listes de messages.

### DIFF
--- a/css/graphisme.css
+++ b/css/graphisme.css
@@ -460,6 +460,19 @@ footer {
 	margin-left: 5px;
 }
 
+/* Cacher la fin des textes longs */
+.overflow {
+	height:600px;
+	overflow:hidden;
+	border-bottom:5px solid #cccccc;
+	width:100%;
+	margin-top: 0;
+}
+
+.overflow:hover {
+background-color:#eeeeee;
+}
+
 /* pour photoswipe */
 .pswp__bg {
 	opacity: 0.6 !important;

--- a/javascript/seenthis/seenthis.js
+++ b/javascript/seenthis/seenthis.js
@@ -345,6 +345,16 @@ $(function () {
 		});
 	//afficher_oe();
 
+
+	// cacher la fin des messages très longs.
+	$('body:not(".message") div.texte > div').each(function(){
+		if($(this).height() > 1000){
+			$(this).css({cursor:'pointer'}).addClass('overflow').click(function(){
+				$(this).toggleClass('overflow');
+			});
+		}	
+	});
+
 	// soundmanager
 	var soundmanager = function () {
 		$('div.audio:not(.soundmanager)')


### PR DESCRIPTION
Dans les listes, on cache la fin des textes long dans une zone cliquable pour ne pas perturber la lecture d'une liste.