### PR TITLE
noms de tables en majuscules

### DIFF
--- a/accueil.html
+++ b/accueil.html
@@ -34,7 +34,7 @@
 <div id="principale">
 	<div>
 
-		<BOUCLE_test5(spip_me_follow){id_follow=#SESSION{id_auteur}}{4,1}>
+		<BOUCLE_test5(ME_FOLLOW){id_follow=#SESSION{id_auteur}}{4,1}>
 		</BOUCLE_test5>
 			<div id="entete_people">
 				<div id="lien_suggerer_auteurs">

--- a/alertes.html
+++ b/alertes.html
@@ -33,15 +33,15 @@
 		#SET{people, #ARRAY{}}
 		<BOUCLE_follow(spip_me_follow){id_follow=#ID_AUTEUR}
 		>[(#SET{people,#GET{people}|push{#ID_AUTEUR}})]</BOUCLE_follow>
-		<BOUCLE_messages_follow(spip_me){id_auteur IN #GET{people}}{par date}{inverse}{doublons}{statut=publi}{id_parent>0}{0,25}
+		<BOUCLE_messages_follow(ME){id_auteur IN #GET{people}}{par date}{inverse}{doublons}{statut=publi}{id_parent>0}{0,25}
 		>[(#ID_ME|stocker_id_me)]</BOUCLE_messages_follow>
 
 
 		<ul>
-		<BOUCLE_alertes(spip_me){id_me IN (#VAL|retour_id_me)}{par date}{inverse}{0,25}>
+		<BOUCLE_alertes(ME){id_me IN (#VAL|retour_id_me)}{par date}{inverse}{0,25}>
 			[(#SET{id_me,#ID_ME})]
 			[(#SET{texte,[(#TEXTE*|replace{"https?://(www\.)*?(\S{1,18}?)\S*?","$2…",UuimsS}|trim|couper{100}|typo)]})]
-			<BOUCLE_parent(spip_me){id_me = #ID_PARENT}>
+			<BOUCLE_parent(ME){id_me = #ID_PARENT}>
 				[(#SET{id_me,#ID_ME})]
 				[(#SET{auteur_parent,#ID_AUTEUR})]
 				

--- a/alertes.html
+++ b/alertes.html
@@ -31,7 +31,7 @@
 	
 		[(#REM) Les reponses des gens que je suis ]
 		#SET{people, #ARRAY{}}
-		<BOUCLE_follow(spip_me_follow){id_follow=#ID_AUTEUR}
+		<BOUCLE_follow(ME_FOLLOW){id_follow=#ID_AUTEUR}
 		>[(#SET{people,#GET{people}|push{#ID_AUTEUR}})]</BOUCLE_follow>
 		<BOUCLE_messages_follow(ME){id_auteur IN #GET{people}}{par date}{inverse}{doublons}{statut=publi}{id_parent>0}{0,25}
 		>[(#ID_ME|stocker_id_me)]</BOUCLE_messages_follow>

--- a/alertes.html
+++ b/alertes.html
@@ -21,7 +21,7 @@
 		</BOUCLE_reponses>
 
 		[(#REM) Les messages qui me mentionnent ]
-		<BOUCLE_liens_vers_moi(spip_me spip_me_auteur)
+		<BOUCLE_liens_vers_moi(ME spip_me_auteur)
 		{spip_me_auteur.id_auteur=#ID_AUTEUR}
 		{id_auteur!=#SESSION{id_auteur}}
 		{statut=publi}

--- a/auteur.html
+++ b/auteur.html
@@ -45,7 +45,7 @@
 					<div id="messages_perso" style="display: none;">
 						[<div class="pagination" id="pagination_haut">(#PAGINATION)</div>]
 						<ul class="messages">
-				<BOUCLE_messages(spip_me){id_me IN #GET{messages_perso}}{par date}{inverse}{id_parent=0}{pagination 25}{statut=publi}>
+				<BOUCLE_messages(ME){id_me IN #GET{messages_perso}}{par date}{inverse}{id_parent=0}{pagination 25}{statut=publi}>
 							<li id="message#ID_ME"><a name="message#ID_ME"></a>
 								[(#ID_ME|microcache{noisettes/message/afficher_message})]
 							</li>

--- a/auteur.html
+++ b/auteur.html
@@ -25,10 +25,10 @@
 		<div id="centre">
 			<div id="tous_messages">
 				#SET{messages_perso, #ARRAY{}}
-				<BOUCLE_mes_messages(spip_me spip_me_auteur)
+				<BOUCLE_mes_messages(ME spip_me_auteur)
 					{spip_me_auteur.id_auteur=(#ID_AUTEUR|sinon{0})}
-					{spip_me.id_auteur=#SESSION{id_auteur}}
-					{spip_me.id_auteur!=#ID_AUTEUR}>
+					{id_auteur=#SESSION{id_auteur}}
+					{id_auteur!=#ID_AUTEUR}>
 						[(#ID_PARENT|>{0}|?{" ",""})
 							[(#SET{messages_perso, #GET{messages_perso}|push{#ID_PARENT}})]
 						]

--- a/backend-liens.html
+++ b/backend-liens.html
@@ -28,7 +28,7 @@ version="1.0"[ encoding="(#CHARSET)"]?>
 		#SET{messages, #ARRAY{}}
 		#SET{liens, #ARRAY{}}
 		
-		<BOUCLE_messages_perso(spip_me){id_auteur}{par date}{inverse}{id_parent=0}{statut=publi}>
+		<BOUCLE_messages_perso(ME){id_auteur}{par date}{inverse}{id_parent=0}{statut=publi}>
 				[(#ID_PARENT|>{0}|?{" ",""})
 					[(#SET{messages, #GET{messages}|push{#ID_PARENT}})]		
 				]
@@ -40,7 +40,7 @@ version="1.0"[ encoding="(#CHARSET)"]?>
 			[(#SET{messages, #GET{messages}|push{#ID_ME}})]		
 		</BOUCLE_share>
 	
-		<BOUCLE_messages(spip_me){id_me IN #GET{messages}}{par date}{inverse}{id_parent=0}{0,40}{statut=publi}>
+		<BOUCLE_messages(ME){id_me IN #GET{messages}}{par date}{inverse}{id_parent=0}{0,40}{statut=publi}>
 		<INCLURE{fond=inc/rss-item-lien}{id_me}>
 		</BOUCLE_messages>
 

--- a/backend_tag.html
+++ b/backend_tag.html
@@ -17,7 +17,7 @@ version="1.0"[ encoding="(#CHARSET)"]?>
 ,
 	[(#SET{tagq,[(#TAG*|likeq)%]})]
 })]
-<BOUCLE_tag(ME spip_me_tags)
+<BOUCLE_tag(ME me_tags)
 	{tag like (#GET{tagq})}
 	{statut=publi}
 	{!par date}

--- a/formulaires/poster_message.html
+++ b/formulaires/poster_message.html
@@ -37,28 +37,29 @@
 
 </div>
 
-	[<p class='envoi_message_ok'>(#ENV**{message_ok}|table_valeur{texte})</p>
-		<script><!--
+[<p class='envoi_message_ok'>(#ENV**{message_ok}|table_valeur{texte})</p>
+	<script><!--
+	if (window.jQuery) {
 		$(function() {
-
 			if ("[(#ENV**{message_ok}|table_valeur{maj})]" > 0) {
 				setTimeout(function () {
 					$("#message[(#ENV**{message_ok}|table_valeur{pave})]")
-							.html("<div class='loading_icone'></div>")
-							.load("index.php?page=inc_afficher_message&id_me=[(#ENV**{message_ok}|table_valeur{pave})]");
+						.html("<div class='loading_icone'></div>")
+						.load("index.php?page=inc_afficher_message&id_me=[(#ENV**{message_ok}|table_valeur{pave})]");
 				}, 30);
 			} else if ("[(#ENV**{message_ok}|table_valeur{ok_parent})]" > 0) {
 				$("#message[(#ENV**{message_ok}|table_valeur{ok_parent})]").find(".formulaire_poster_message").hide();
 				$("#message[(#ENV**{message_ok}|table_valeur{ok_parent})]")
-						.load("index.php?page=inc_afficher_message&id_me=[(#ENV**{message_ok}|table_valeur{ok_parent})]&nouveau=[(#ENV**{message_ok}|table_valeur{ok_me})]")
-						.slideDown();
+					.load("index.php?page=inc_afficher_message&id_me=[(#ENV**{message_ok}|table_valeur{ok_parent})]&nouveau=[(#ENV**{message_ok}|table_valeur{ok_me})]")
+					.slideDown();
 			} else {
 				$(".formulaire_poster_message").removeClass("focus").find("textarea").hide();
 				$("#messages").prepend("<li id='message[(#ENV**{message_ok}|table_valeur{ok_me})]'></li>");
 				$("#message[(#ENV**{message_ok}|table_valeur{ok_me})]")
-						.html("<div class='loading_icone'></div>")
-						.load("index.php?page=inc_afficher_message&id_me=[(#ENV**{message_ok}|table_valeur{ok_me})]&nouveau=[(#ENV**{message_ok}|table_valeur{ok_me})]");
+					.html("<div class='loading_icone'></div>")
+					.load("index.php?page=inc_afficher_message&id_me=[(#ENV**{message_ok}|table_valeur{ok_me})]&nouveau=[(#ENV**{message_ok}|table_valeur{ok_me})]");
 			}
 		});
-		--></script>
-	]
+	}
+	--></script>
+]

--- a/inc/rss-item-lien.html
+++ b/inc/rss-item-lien.html
@@ -1,5 +1,5 @@
 
-<BOUCLE_un_message(spip_me){id_me}{tous}>
+<BOUCLE_un_message(ME){id_me}{tous}>
 	<item[ xml:lang="(#LANG)"]>
 		<title>[(#TEXTE*|extraire_titre|supprimer_tags|texte_backend)]</title>
 

--- a/inc/rss-item.html
+++ b/inc/rss-item.html
@@ -1,5 +1,5 @@
 
-<BOUCLE_un_message(spip_me){id_me}{tous}>
+<BOUCLE_un_message(ME){id_me}{tous}>
 	<item[ xml:lang="(#LANG)"]>
 		<title>[(#TEXTE*|extraire_titre|supprimer_tags|texte_backend)]</title>
 

--- a/modifier_me.html
+++ b/modifier_me.html
@@ -1,6 +1,6 @@
 #CACHE{0}
 [(#HTTP_HEADER{Content-type: text/html[; charset=(#CHARSET)]})]
-<BOUCLE_principale(spip_me){tout}{id_me}{id_auteur=#SESSION{id_auteur}}>
+<BOUCLE_principale(ME){tout}{id_me}{id_auteur=#SESSION{id_auteur}}>
 	[(#FORMULAIRE_POSTER_MESSAGE{#ID_ME})]
 </BOUCLE_principale>
 	INTERDIT

--- a/mot.html
+++ b/mot.html
@@ -48,7 +48,7 @@
 
 		<div id="entete_people">
 			<ul class="parents_url">
-			<BOUCLE_parents(spip_me_tags)
+			<BOUCLE_parents(ME_TAGS)
 				{si #ENV*{tag}|match{^#}}
 				{tag IN (#ENV*{tag}|precurseurs)}
 				{fusion tag}

--- a/mot_fin.html
+++ b/mot_fin.html
@@ -53,7 +53,7 @@
 
 		<div id="entete_people">
 			<ul class="parents_url">
-				<BOUCLE_parents(spip_me_tags)
+				<BOUCLE_parents(ME_TAGS)
 					{si #ENV{tag}|match{^#}}
 					{tag IN (#ENV{tag}|precurseurs)}
 					{fusion tag}

--- a/noisettes/afficher_me_xml.html
+++ b/noisettes/afficher_me_xml.html
@@ -7,7 +7,7 @@
 
 		<B_mots>
 			<tags>
-		<BOUCLE_mots(spip_me_tags){id_me}{class='#'}{fusion tag}{par tag}>
+		<BOUCLE_mots(ME_TAGS){id_me}{class='#'}{fusion tag}{par tag}>
 				[<tag href="[(#URL_TAG|url_absolue)]">(#TAG*|replace{#}|cdata)</tag>]
 		</BOUCLE_mots>
 			</tags>
@@ -15,7 +15,7 @@
 
 		<B_liens>
 			<urls>
-		<BOUCLE_liens(spip_me_tags){id_me}{class=url}{fusion tag}>
+		<BOUCLE_liens(ME_TAGS){id_me}{class=url}{fusion tag}>
 			[<url href="[(#URL_TAG|url_absolue)]">(#TAG*|cdata)</url>]
 		</BOUCLE_liens>
 			</urls>

--- a/noisettes/atom/atom_me.html
+++ b/noisettes/atom/atom_me.html
@@ -1,6 +1,6 @@
 #CACHE{0}
 
-<BOUCLE_me(spip_me){id_me=#ID}{statut=publi}>
+<BOUCLE_me(ME){id_me=#ID}{statut=publi}>
 <entry>
 	[<id>urn:uuid:(#UUID)</id>]
 	<title>[(#TEXTE*|extraire_titre|texte_backend)]</title>

--- a/noisettes/atom/atom_me.html
+++ b/noisettes/atom/atom_me.html
@@ -21,7 +21,7 @@
 	<BOUCLE_liens(SITES spip_me_syndic) {spip_me_syndic.id_me=#ID_ME}>
 	<link rel="related" href="#URL_SITE"[ title="(#TITRE|replace{'"', "'"}|texte_backend)"][ hreflang="(#LANG)"]/>
 	</BOUCLE_liens>
-	<BOUCLE_tags(spip_me_tags){id_me}{class IN '#','oc'}{fusion tag}>
+	<BOUCLE_tags(ME_TAGS){id_me}{class IN '#','oc'}{fusion tag}>
 	<category term="[(#TAG*|replace{'"', "'"}|replace{#}|texte_backend)]" label="[(#TAG*|replace{'"', "'"}|replace{#}|replace{^.*:}|texte_backend)]" scheme="[(#URL_TAG|url_absolue{#EVAL{_HTTPS}://#EVAL{_HOST}/})]"/></BOUCLE_tags>
 </entry>
 </BOUCLE_me>

--- a/noisettes/atom/atom_me_tw.html
+++ b/noisettes/atom/atom_me_tw.html
@@ -1,6 +1,6 @@
 #CACHE{0}
 
-<BOUCLE_me(spip_me){id_me=#ID}{statut=publi}>
+<BOUCLE_me(ME){id_me=#ID}{statut=publi}>
 <entry>
 	[<id>urn:uuid:(#UUID)</id>]
 	<title>[(#TEXTE*|extraire_titre|texte_backend)]</title>

--- a/noisettes/atom/atom_me_tw.html
+++ b/noisettes/atom/atom_me_tw.html
@@ -20,7 +20,7 @@
 	<BOUCLE_liens(SITES spip_me_syndic) {spip_me_syndic.id_me=#ID_ME}>
 	<link rel="related" href="#URL_SITE"[ title="(#TITRE|replace{'"', "'"}|texte_backend)"][ hreflang="(#LANG)"]/>
 	</BOUCLE_liens>
-	<BOUCLE_tags(spip_me_tags){id_me}{class IN '#','oc'}{fusion tag}>
+	<BOUCLE_tags(ME_TAGS){id_me}{class IN '#','oc'}{fusion tag}>
 	<category term="[(#TAG*|replace{'"', "'"}|replace{#}|texte_backend)]" label="[(#TAG*|replace{'"', "'"}|replace{#}|replace{^.*:}|texte_backend)]" scheme="[(#URL_TAG|url_absolue{#EVAL{_HTTPS}://#EVAL{_HOST}/})]"/></BOUCLE_tags>
 </entry>
 </BOUCLE_me>

--- a/noisettes/auteur_follow_people.html
+++ b/noisettes/auteur_follow_people.html
@@ -3,7 +3,7 @@
 <B_follow>
 	<div class="following following_people">
 		<h3><span class="vous_suivez"><:seenthis:vous_suivez:></span> <strong>#TOTAL_BOUCLE</strong></h3>
-<BOUCLE_follow(spip_me_follow){id_follow=#ENV{id}}{id_auteur>0}>
+<BOUCLE_follow(ME_FOLLOW){id_follow=#ENV{id}}{id_auteur>0}>
 		[(#SET{follow_people, #GET{follow_people}|push{#ID_AUTEUR}})]
 </BOUCLE_follow>
 

--- a/noisettes/auteur_follow_people_big.html
+++ b/noisettes/auteur_follow_people_big.html
@@ -2,7 +2,7 @@
 <BOUCLE_principale(AUTEURS){id_auteur=#ENV{id}}{tout}>
 	#SET{follow_people, #ARRAY{}}
 
-	<BOUCLE_follow(spip_me_follow){id_follow=#ID_AUTEUR}>
+	<BOUCLE_follow(ME_FOLLOW){id_follow=#ID_AUTEUR}>
 		[(#SET{follow_people, #GET{follow_people}|push{#ID_AUTEUR}})]		
 	</BOUCLE_follow>
 	

--- a/noisettes/auteur_followed.html
+++ b/noisettes/auteur_followed.html
@@ -2,7 +2,7 @@
 #SET{followed_people, #ARRAY{}}
 
 <B_follow>
-<BOUCLE_follow(spip_me_follow){id_auteur=#ENV{id}}>
+<BOUCLE_follow(ME_FOLLOW){id_auteur=#ENV{id}}>
 	[(#SET{followed_people, #GET{followed_people}|push{#ID_FOLLOW}})]
 </BOUCLE_follow>
 	<div class="followed">

--- a/noisettes/contenu/contenu_mot.html
+++ b/noisettes/contenu/contenu_mot.html
@@ -8,7 +8,7 @@
 
 [(#REM) pas efficace: il faut un critere qui retienne id_me OU parent dans DOUBLONS ]
 #SET{parents,#ARRAY}
-<BOUCLE_tag(ME spip_me_tags)
+<BOUCLE_tag(ME me_tags)
 	{tag like (#TAG*|likeq)%}
 	{statut=publi}
 	{!par date}

--- a/noisettes/contenu/contenu_mot_fin.html
+++ b/noisettes/contenu/contenu_mot_fin.html
@@ -2,7 +2,7 @@
 #SET{messages, #ARRAY{}}
 [(#REM) todo: remettre OpenCalais sur les sites ; ne marche plus ]
 
-<BOUCLE_tous_liens(spip_me spip_me_tags){tag}{off!=oui}>
+<BOUCLE_tous_liens(ME me_tags){tag}{off!=oui}>
 	[(#ID_PARENT|>{0}|?{" ",""})
 		[(#SET{messages, #GET{messages}|push{#ID_PARENT}})]		
 	]

--- a/noisettes/contenu/contenu_mot_fin.html
+++ b/noisettes/contenu/contenu_mot_fin.html
@@ -15,7 +15,7 @@
 	<B_messages>
 		[<div class="pagination" id="pagination_haut">(#PAGINATION)</div>]
 		<ul id="messages">
-	<BOUCLE_messages(spip_me){id_me IN #GET{messages}}{troll>1}{par date}{inverse}{id_parent=0}{pagination 25}{statut=publi}>
+	<BOUCLE_messages(ME){id_me IN #GET{messages}}{troll>1}{par date}{inverse}{id_parent=0}{pagination 25}{statut=publi}>
 			<li id="message#ID_ME">
 				[(#ID_ME|microcache{noisettes/message/afficher_message})]
 			</li>

--- a/noisettes/contenu/contenu_mot_flou.html
+++ b/noisettes/contenu/contenu_mot_flou.html
@@ -1,5 +1,5 @@
 #CACHE{0}
-<BOUCLE_tous_mots(spip_me_tags spip_me)
+<BOUCLE_tous_mots(ME_TAGS me)
 {tag like (#TAG*|likeq)%}
 {!par date}
 {0,500}
@@ -10,10 +10,10 @@
 <BOUCLE_me(ME){id_me IN #GET{messages}|explode{' '}|array_filter}{statut=publi}{doublons pourmots}{!par date}{0,200} />
 
 
-	<BOUCLE_mots(spip_me_tags){id_me IN #DOUBLONS{mepourmots}}
+	<BOUCLE_mots(ME_TAGS){id_me IN #DOUBLONS{mepourmots}}
 		{class IN #,oc}
 		>[(#TAG*|compter_mots_lies)]</BOUCLE_mots>
-	<BOUCLE_mots_reponses(spip_me_tags spip_me){spip_me.id_parent IN #DOUBLONS{mepourmots}}
+	<BOUCLE_mots_reponses(ME_TAGS me){me.id_parent IN #DOUBLONS{mepourmots}}
 		{class IN #,oc}
 		>[(#TAG*|compter_mots_lies)]</BOUCLE_mots_reponses>
 

--- a/noisettes/contenu/contenu_mot_flou.html
+++ b/noisettes/contenu/contenu_mot_flou.html
@@ -29,7 +29,7 @@
 
 [(#REM) note : array_slice=4 permet de prendre les 10 mots les plus lies au mot recherche ]
 #SET{parents,#ARRAY}
-<BOUCLE_tag(ME spip_me_tags)
+<BOUCLE_tag(ME me_tags)
 	{tag IN #REM*|retour_mots_lies|array_slice{0,10}}
 	{statut=publi}
 	{!par date}

--- a/noisettes/contenu/contenu_page_people.html
+++ b/noisettes/contenu/contenu_page_people.html
@@ -10,7 +10,7 @@
 ]
 
 #SET{messages,#ARRAY{}}
-<BOUCLE_follow(spip_me)
+<BOUCLE_follow(ME)
 	{id_auteur IN (#ENV{id}|liste_follow)}
 	{statut=publi}
 	{!par date}
@@ -24,7 +24,7 @@
 <B_messages>
 	[<div class="pagination" id="pagination_haut">(#PAGINATION)</div>]
 	<ul id="messages">
-<BOUCLE_messages(spip_me){id_me IN #GET{messages}}{pagination 25}{statut=publi}{!par date}>
+<BOUCLE_messages(ME){id_me IN #GET{messages}}{pagination 25}{statut=publi}{!par date}>
 		<li id="message#ID_ME">
 			[(#ID_ME|microcache{noisettes/message/afficher_message})]
 		</li>

--- a/noisettes/contenu/contenu_site.html
+++ b/noisettes/contenu/contenu_site.html
@@ -20,7 +20,7 @@
 	<B_messages>
 		[<div class="pagination" id="pagination_haut">(#PAGINATION)</div>]
 		<ul id="messages">
-	<BOUCLE_messages(spip_me){id_me IN #GET{messages}}{par date}{follow #GET{follow}}{inverse}{id_parent=0}{pagination 20}{statut=publi}>
+	<BOUCLE_messages(ME){id_me IN #GET{messages}}{par date}{follow #GET{follow}}{inverse}{id_parent=0}{pagination 20}{statut=publi}>
 			<li id="message#ID_ME">
 				<INCLURE{fond=inc_afficher_message}{id_me}>
 			</li>

--- a/noisettes/entete_auteur_message.html
+++ b/noisettes/entete_auteur_message.html
@@ -1,4 +1,4 @@
 #CACHE{0}
-<BOUCLE_principale(spip_me){tout}{id_me=#ENV{id}}>
+<BOUCLE_principale(ME){tout}{id_me=#ENV{id}}>
 	[(#ID_AUTEUR|microcache{noisettes/entete_auteur})]
 </BOUCLE_principale>

--- a/noisettes/head_message.html
+++ b/noisettes/head_message.html
@@ -1,6 +1,6 @@
 #CACHE{0}
 <meta charset="#CHARSET">
-<BOUCLE_principale(spip_me){tout}{id_me=#ENV{id}}>
+<BOUCLE_principale(ME){tout}{id_me=#ENV{id}}>
 	<link rel="canonical" href="#URL_SITE_SPIP/messages/#ID_ME">
 	[(#SET{texte_star,#TEXTE*})]
 	[<title>(#GET{texte_star}|extraire_titre)</title>]

--- a/noisettes/message/afficher_message.html
+++ b/noisettes/message/afficher_message.html
@@ -6,7 +6,7 @@
 	<B_reponses>
 		<div class="conteneur_reponses">
 		<ul class="reponses">
-	<BOUCLE_reponses(spip_me){id_parent=#ID_ME}{par date}{statut=publi}>
+	<BOUCLE_reponses(ME){id_parent=#ID_ME}{par date}{statut=publi}>
 			<li class="reponse">
 				<INCLUDE{fond=noisettes/message/afficher_un_message}{id=#ID_ME} />
 			</li>
@@ -23,7 +23,7 @@
 		</div>
 </section>
 </BOUCLE_principale>
-	<BOUCLE_efface(spip_me){id_me=#ENV{id}}{statut==.*}>
+	<BOUCLE_efface(ME){id_me=#ENV{id}}{statut==.*}>
 		[(#REM) Tout autre statut que "publi" correspond a un message efface ]
 		<section>
 			<h1>Message effacé</h1>

--- a/noisettes/message/afficher_message.html
+++ b/noisettes/message/afficher_message.html
@@ -1,5 +1,5 @@
 ﻿#CACHE{0}
-<BOUCLE_principale(spip_me){id_me=#ENV{id}}{statut=publi}>
+<BOUCLE_principale(ME){id_me=#ENV{id}}{statut=publi}>
 <section class="auteur#ID_AUTEUR">
 	<INCLUDE{fond=noisettes/message/afficher_un_message}{id=#ID_ME} />
 

--- a/noisettes/message/afficher_un_message.html
+++ b/noisettes/message/afficher_un_message.html
@@ -1,5 +1,5 @@
 #CACHE{0}
-<BOUCLE_me(spip_me){id_me=#ID}>
+<BOUCLE_me(ME){id_me=#ID}>
 	<article data-article-id="[(#ID_ME)]">
 		<a name="message#ID_ME"></a>
 
@@ -33,7 +33,7 @@
 				<div class="supprimer"><a
 					onclick="confirm(texte_effacer+'?') && $('#texte#ID').fadeOut().load('index.php?action=delete&amp;id_me=#ID_ME'); return false;"
 					href="#" 
-					rel="^(#ID_AUTEUR<BOUCLE_racine(spip_me){id_me=#ID_PARENT}>|#ID_AUTEUR</BOUCLE_racine>)$"></a>
+					rel="^(#ID_AUTEUR<BOUCLE_racine(ME){id_me=#ID_PARENT}>|#ID_AUTEUR</BOUCLE_racine>)$"></a>
 				</div>
 				<div class="modifier"><a
 					onclick="$('#texte#ID').load('index.php?page=modifier_me&amp;id_me=#ID_ME&amp;x=' + (new Date()).getTime() ); if ($('#texte#ID').offset().top >= (scrolltop = self['pageYOffset'] || $.boxModel && document.documentElement[ 'scrollTop' ] || document.body[ 'scrollTop' ])) return false;"	

--- a/noisettes/message_texte.html
+++ b/noisettes/message_texte.html
@@ -1,5 +1,5 @@
 #CACHE{0}
-<BOUCLE_me(spip_me){id_me=#ID}{statut=publi}>
+<BOUCLE_me(ME){id_me=#ID}{statut=publi}>
 			<div class="texte">[(#TEXTE|liens_troll{#ID_AUTEUR})]</div>
 </BOUCLE_me>
 #FILTRE{mini_html}

--- a/noisettes/mots_lies/mots_lies.html
+++ b/noisettes/mots_lies/mots_lies.html
@@ -1,7 +1,7 @@
 #CACHE{60*60}
 [(#REM)Les mots liés : il s'agit des mots les plus courants dans les 100 derniers messages publiés associés au mot demandé (ainsi qu'à ses enfants), ainsi que dans leurs réponses]
 
-<BOUCLE_tous_mots(spip_me_tags spip_me){tag like (#TAG*|likeq)%}
+<BOUCLE_tous_mots(ME_TAGS me){tag like (#TAG*|likeq)%}
 {!par date}
 {0,150}
 >
@@ -10,10 +10,10 @@
 ]</BOUCLE_tous_mots>
 
 <BOUCLE_messages(ME){id_me IN #GET{messages}|explode{' '}|array_filter}{statut=publi}{doublons pourmots}{!par date}{0,100} />
-	<BOUCLE_mots(spip_me_tags){id_me IN #DOUBLONS{mepourmots}}
+	<BOUCLE_mots(ME_TAGS){id_me IN #DOUBLONS{mepourmots}}
 		{class IN #,oc}
 		>[(#TAG*|compter_mots_lies)]</BOUCLE_mots>
-	<BOUCLE_mots_reponses(spip_me_tags spip_me){spip_me.id_parent IN #DOUBLONS{mepourmots}}
+	<BOUCLE_mots_reponses(ME_TAGS me){me.id_parent IN #DOUBLONS{mepourmots}}
 		{class IN #,oc}
 		>[(#TAG*|compter_mots_lies)]</BOUCLE_mots_reponses>
 

--- a/noisettes/mots_lies/mots_lies_auteur.html
+++ b/noisettes/mots_lies/mots_lies_auteur.html
@@ -1,7 +1,7 @@
 #CACHE{0}
 <BOUCLE_principale(AUTEURS){id_auteur}{tout}>
 	<BOUCLE_messages(ME){follow #ID_AUTEUR}{par date}{inverse}{id_parent=0}{0,500}{statut=publi}{doublons me} />
-	<BOUCLE_tags(spip_me_tags){id_me IN #DOUBLONS{meme}}{class!=url}>
+	<BOUCLE_tags(ME_TAGS){id_me IN #DOUBLONS{meme}}{class!=url}>
 	[(#TAG*|compter_mots_lies)]</BOUCLE_tags>
 
 	<B_resultat>

--- a/noisettes/mots_lies/mots_lies_general.html
+++ b/noisettes/mots_lies/mots_lies_general.html
@@ -1,5 +1,5 @@
 #CACHE{30*60}
-<BOUCLE_recents(me spip_me_tags)
+<BOUCLE_recents(ME me_tags)
 	{!par troll}
 	{date>(#VAL{Y-m-d}|date{#DATE|strtotime|moins{864000}})}
 	{fusion id_auteur}{class='#'}{0,1000}>[(#TAG*|compter_mots_lies)]</BOUCLE_recents>
@@ -7,7 +7,7 @@
 <B_resultat>
 	<div id="scroller">
 		<ul id="scroll_tags">
-<BOUCLE_resultat(spip_me_tags){tag IN (#REM|retour_mots_lies)}{fusion tag}{0,30}>
+<BOUCLE_resultat(ME_TAGS){tag IN (#REM|retour_mots_lies)}{fusion tag}{0,30}>
 			<li>#<a href="[(#URL_TAG)]">[(#TAG|replace{#})]</a></li>
 </BOUCLE_resultat>
 		</ul>

--- a/recherche.html
+++ b/recherche.html
@@ -45,7 +45,7 @@
 			<div id="enfants_mots">
 				<B_enfants>
 					<ul>
-				<BOUCLE_enfants(spip_me_tags)
+				<BOUCLE_enfants(ME_TAGS)
 				{tag LIKE #(#ENV{recherche}|likeq)%}
 				{class=#}
 				{fusion tag}

--- a/suggerer_auteurs.html
+++ b/suggerer_auteurs.html
@@ -2,12 +2,12 @@
 <BOUCLE_auteur(AUTEURS){tout}{id_auteur=#SESSION{id_auteur}}{doublons}{lang_select}>
 
 	#SET{vus,#ARRAY}
-	<BOUCLE_suivis(spip_me_follow){id_follow=#ID_AUTEUR}>
+	<BOUCLE_suivis(ME_FOLLOW){id_follow=#ID_AUTEUR}>
 	#SET{vus,#GET{vus}|push{#ID_AUTEUR}}
 	</BOUCLE_suivis>
 	<BOUCLE_vus(AUTEURS){tout}{id_auteur IN #GET{vus}}{doublons} />
 
-	<BOUCLE_quisuit(spip_me_follow)
+	<BOUCLE_quisuit(ME_FOLLOW)
 		{id_follow IN #DOUBLONS{auteurs}}
 		{id_auteur !IN #DOUBLONS{auteurs}}
 	>[(#ID_AUTEUR|compter_auteurs)]</BOUCLE_quisuit>


### PR DESCRIPTION
Pour compléter #43 : remplacement pour me, me_tags et me_follow + adaptation de la syntaxe des jointures quand nécessaire

Pour chaque changement, j'ai comparé la requête SQL générée avant et après (tests effectués sur SPIP 3). Cadeau bonus, ça répare la génération de certaines jointures qui ne se faisaient plus sous SPIP 3.