### PR TITLE
init js afficher_traduire() dans js.textes_interface

### DIFF
--- a/javascript/seenthis/seenthis.js
+++ b/javascript/seenthis/seenthis.js
@@ -247,7 +247,6 @@ $(function () {
 	}
 
 	favoris_actifs();
-	afficher_traduire();
 	if (language == "ar") {
 		bodyElement.attr("dir", "rtl").addClass("lang-ar");
 

--- a/js.textes_interface.html
+++ b/js.textes_interface.html
@@ -146,6 +146,8 @@ if (auteur_page > 0) {
 	$("#charger_pave_inscription").load("index.php?page=pave_inscription&lang=[(#GET{lalangue})]");
 }
 
+afficher_traduire();
+
 $(document).ajaxComplete(function(e, xhr, settings){
 	afficher_traduire();
 	afficher_textes_traduits();


### PR DESCRIPTION
idem que pour l'init lors d'un retour ajax, ce qui permet de cibler cette fonction plus facilement si on souhaite s'en passer