### PR TITLE
Améliorer la détection des urls identiques lors de la rédaction d'un message

### DIFF
--- a/action/messages_lien.php
+++ b/action/messages_lien.php
@@ -10,7 +10,9 @@ function action_messages_lien() {
 	$url = rawurldecode(_request("url"));
 	spip_log($url);
 	$url_messages = array();
-	$id_possibles = sql_allfetsel('id_me', 'spip_me_tags', 'class = '.sql_quote('url').' and tag = '.sql_quote(preg_replace(',/$,', '', $url)));
+	// virer le http/https en début d'url + le slash final
+	$url = preg_replace(',/$,', '', preg_replace(',^(https?://)?,i', '',$url));
+	$id_possibles = sql_allfetsel('id_me', 'spip_me_tags', 'class = '.sql_quote('url').' and tag LIKE '.sql_quote('%' . $url));
 	$id_publies = sql_allfetsel(
 		'id_me',
 		'spip_me', array("statut = 'publi'", sql_in('id_me', array_map('array_pop', $id_possibles))));

--- a/action/messages_lien.php
+++ b/action/messages_lien.php
@@ -8,11 +8,10 @@ function action_messages_lien() {
 	if ($auteur_session < 1) exit;
 
 	$url = rawurldecode(_request("url"));
-	spip_log($url);
 	$url_messages = array();
 	// virer le http/https en début d'url + le slash final
-	$url = preg_replace(',/$,', '', preg_replace(',^(https?://)?,i', '', $url));
-	$id_possibles = sql_allfetsel('id_me', 'spip_me_tags', 'class = '.sql_quote('url').' and (tag = '.sql_quote('http://' . $url).' or tag = '.sql_quote('https://' . $url).')');
+	$lien_flou = preg_replace(',/$,', '', preg_replace(',^(https?://)?,i', '', $url));
+	$id_possibles = sql_allfetsel('id_me', 'spip_me_tags', 'class = '.sql_quote('url').' and (tag = '.sql_quote('http://' . $lien_flou).' or tag = '.sql_quote('https://' . $lien_flou).')');
 	$id_publies = sql_allfetsel(
 		'id_me',
 		'spip_me', array("statut = 'publi'", sql_in('id_me', array_map('array_pop', $id_possibles))));

--- a/action/messages_lien.php
+++ b/action/messages_lien.php
@@ -11,7 +11,7 @@ function action_messages_lien() {
 	spip_log($url);
 	$url_messages = array();
 	// virer le http/https en début d'url + le slash final
-	$url = preg_replace(',/$,', '', preg_replace(',^(https?://)?,i', '',$url));
+	$url = preg_replace(',/$,', '', preg_replace(',^(https?://)?,i', '', $url));
 	$id_possibles = sql_allfetsel('id_me', 'spip_me_tags', 'class = '.sql_quote('url').' and tag LIKE '.sql_quote('%' . $url));
 	$id_publies = sql_allfetsel(
 		'id_me',

--- a/action/messages_lien.php
+++ b/action/messages_lien.php
@@ -12,7 +12,7 @@ function action_messages_lien() {
 	$url_messages = array();
 	// virer le http/https en début d'url + le slash final
 	$url = preg_replace(',/$,', '', preg_replace(',^(https?://)?,i', '', $url));
-	$id_possibles = sql_allfetsel('id_me', 'spip_me_tags', 'class = '.sql_quote('url').' and tag LIKE '.sql_quote('%' . $url));
+	$id_possibles = sql_allfetsel('id_me', 'spip_me_tags', 'class = '.sql_quote('url').' and (tag = '.sql_quote('http://' . $url).' or tag = '.sql_quote('https://' . $url).')');
 	$id_publies = sql_allfetsel(
 		'id_me',
 		'spip_me', array("statut = 'publi'", sql_in('id_me', array_map('array_pop', $id_possibles))));

--- a/seenthissq_fonctions.php
+++ b/seenthissq_fonctions.php
@@ -30,9 +30,12 @@ function share_tw_url($id_me) {
 function calculer_enfants_syndic($id_syndic, $url_racine = '', $afficher_url = '', $ret = array()) {
 	
 	$ret[] = $id_syndic;
-//	if (!$afficher_url) $afficher_url = $url_racine;
 	
-		
+	// si on a la même url en http & https, ajouter le doublon au tableau de retour
+	$lien_flou = preg_replace(',/$,', '', preg_replace(',^(https?://)?,i', '', $url_racine));
+	if ($doublon = sql_getfetsel('id_syndic', 'spip_syndic', "id_syndic != $id_syndic AND url_site LIKE ".sql_quote('%' . $lien_flou))) {
+		$ret[] = $doublon;
+	}
 	
 	$query = sql_select("*", "spip_syndic", "id_parent=$id_syndic", /* group by */ '', /* order by*/ '', /* limit */ '0,100');
 	$total = sql_count($query);

--- a/seenthissq_fonctions.php
+++ b/seenthissq_fonctions.php
@@ -33,7 +33,7 @@ function calculer_enfants_syndic($id_syndic, $url_racine = '', $afficher_url = '
 	
 	// si on a la même url en http & https, ajouter le doublon au tableau de retour
 	$lien_flou = preg_replace(',/$,', '', preg_replace(',^(https?://)?,i', '', $url_racine));
-	if ($doublon = sql_getfetsel('id_syndic', 'spip_syndic', "id_syndic != $id_syndic AND url_site LIKE ".sql_quote('%' . $lien_flou))) {
+	if ($doublon = sql_getfetsel('id_syndic', 'spip_syndic', "id_syndic != $id_syndic and (url_site = ".sql_quote('http://' . $lien_flou)." or url_site = ".sql_quote('https://' . $lien_flou).")")) {
 		$ret[] = $doublon;
 	}
 	


### PR DESCRIPTION
matcher les urls en http/https comme identiques dans action_messages_lien() / ref https://github.com/seenthis/seenthis_squelettes/issues/130