### PR TITLE
Ajout de la possibilité de replier le fil des commentaires une fois déplié

### DIFF
--- a/css/messages.css
+++ b/css/messages.css
@@ -707,11 +707,23 @@ ul#messages, ul.messages {
 					}
 				}
 				
-				. .masquer {
+				. .masquer:not(:first-of-type) {
 					opacity: 0;
 					height: 0;
 					overflow: hidden;
 				}
+				. .masquer {
+					.msg_afficher {
+						display: none;
+					}
+					.msg_masquer {
+						display: inline;
+					}
+				}
+				.msg_masquer {
+					display: none;
+				}
+
 				. .lienshow {
 					padding-top: 13px;
 					padding-left: 103px;
@@ -723,6 +735,11 @@ ul#messages, ul.messages {
 					
 					. :hover {
 						color: white;
+					}
+
+					. .masquer {
+						padding-bottom: 5px;
+						padding-top: 8px;
 					}
 				}
 			}

--- a/javascript/seenthis/seenthis.js
+++ b/javascript/seenthis/seenthis.js
@@ -82,11 +82,7 @@ function favoris_actifs() {
 }
 
 $.fn.afficher_masques = function () {
-//	var max = count($(this).parents('ul.reponses').children('li'));
-	//console.log('max = ' + max);
 	$(this).parents('ul.reponses').children('li:lt(-2)').toggleClass('masquer');
-	//$(this).remove();
-	//$(this).on('click', plier_messages());
 };
 
 function afficher_traduire() {

--- a/javascript/seenthis/seenthis.js
+++ b/javascript/seenthis/seenthis.js
@@ -82,8 +82,11 @@ function favoris_actifs() {
 }
 
 $.fn.afficher_masques = function () {
-	$(this).parents('ul.reponses').children('li.masquer').removeClass('masquer');
-	$(this).remove();
+//	var max = count($(this).parents('ul.reponses').children('li'));
+	//console.log('max = ' + max);
+	$(this).parents('ul.reponses').children('li:lt(-2)').toggleClass('masquer');
+	//$(this).remove();
+	//$(this).on('click', plier_messages());
 };
 
 function afficher_traduire() {

--- a/js.textes_interface.html
+++ b/js.textes_interface.html
@@ -29,7 +29,9 @@
 							$(this).addClass("masquer");
 						}
 					});
-					$(this).prepend("<li class='reponse lienshow' onclick=\"$(this).afficher_masques();\">"+ traductionSeenThis.montrer_messages.replace("@total@", total) +"</li>");
+					var aff_masq = "<li class='reponse lienshow' onclick=\"$(this).afficher_masques();\">"+ traductionSeenThis.montrer_messages.replace("@total@", total) ;
+					aff_masq += "<span class='msg_masquer'>" + traductionSeenThis.masquer_messages + "</span></li>"
+					$(this).prepend(aff_masq);
 				}
 			});
 		}
@@ -134,7 +136,8 @@ var traductionSeenThis = {
 	bookmarklet_titre: '<:seenthis:bookmarklet_titre|texte_script:>',
 	bookmarklet_descriptif: '<:seenthis:bookmarklet_descriptif|texte_script:>',
 
-	montrer_messages: '<:seenthis:montrer_messages|texte_script:>'
+	montrer_messages: '<:seenthis:montrer_messages|texte_script:>',
+	masquer_messages: '<:seenthis:masquer_messages|texte_script:>'
 };
 
 afficher_textes_traduits_une_fois();

--- a/js.textes_interface.html
+++ b/js.textes_interface.html
@@ -29,7 +29,7 @@
 							$(this).addClass("masquer");
 						}
 					});
-					var aff_masq = "<li class='reponse lienshow' onclick=\"$(this).afficher_masques();\">"+ traductionSeenThis.montrer_messages.replace("@total@", total) ;
+					var aff_masq = "<li class='reponse lienshow' onclick=\"$(this).afficher_masques();\"><span class='msg_afficher'>"+ traductionSeenThis.montrer_messages.replace("@total@", total) + "</span>";
 					aff_masq += "<span class='msg_masquer'>" + traductionSeenThis.masquer_messages + "</span></li>"
 					$(this).prepend(aff_masq);
 				}

--- a/lang/seenthis_fr.php
+++ b/lang/seenthis_fr.php
@@ -52,6 +52,7 @@ Vous pouvez le réactiver depuis votre page de préférences, en supprimant l’
 	'logout' => 'se déconnecter',
 
 	// M
+	'masquer_messages' => 'masquer les messages',
 	'me_suggerer_contacts' => 'Me suggérer des contacts',
 	'message_inscription' => '<strong>Inscription gratuite et immédiate</strong><br />Dès l’enregistrement, votre mot de passe vous est expédié par email.',
 	'message_suggerer' => '

--- a/lang/seenthis_fr.php
+++ b/lang/seenthis_fr.php
@@ -15,12 +15,12 @@ $GLOBALS[$GLOBALS['idx_lang']] = array(
 	'annuler' => 'Annuler',
 	'aucun_message' => 'Aucun message',
 	'auteur_block' => 'Bloquer @people@',
-	'auteur_block_you' => 'Cet auteur vous a bloqué. Vous ne pouvez pas commenter ses messages.',
+	'auteur_block_you' => 'Cet auteur·e vous a bloqué. Vous ne pouvez pas commenter ses messages.',
 	'auteur_ne_plus_block' => 'Débloquer @people@',
 	'auteur_ne_plus_suivre' => 'Ne plus suivre @people@',
 	'auteur_vous_block' => 'Vous avez bloqué @people@',
 	'auteur_vous_suivez' => 'Vous suivez @people@',
-	'auteurs_vous_suivez' => 'Les auteurs que vous suivez',
+	'auteurs_vous_suivez' => 'Les auteur·es que vous suivez',
 
 	// B
 	'beta_publique' => '<strong>Seenthis est en beta publique.</strong><br />Vous pouvez vous inscrire et participer, merci pour votre patience et votre bonne volonté durant cette phase.',
@@ -56,14 +56,14 @@ Vous pouvez le réactiver depuis votre page de préférences, en supprimant l’
 	'me_suggerer_contacts' => 'Me suggérer des contacts',
 	'message_inscription' => '<strong>Inscription gratuite et immédiate</strong><br />Dès l’enregistrement, votre mot de passe vous est expédié par email.',
 	'message_suggerer' => '
-				<strong>Nouveau sur Seenthis ? Vous devriez commencer par suivre des auteurs.</strong>
+				<strong>Nouveau sur Seenthis ? Vous devriez commencer par suivre des auteur·es.</strong>
 				<p>Cliquez sur le bouton « Me suggérer des contacts » ci-contre, et 
-				visitez les pages des auteurs proposés. Si un auteur vous intéresse, suivez-le en cliquant, 
-				en haut de page, sur « Suivre cet auteur ».
+				visitez les pages des auteur·es proposés. Si un auteur·e vous intéresse, suivez-le en cliquant, 
+				en haut de page, sur « Suivre cet auteur·e ».
 				Puis revenez sur cette page, recommencez l’opération, les propositions s’affineront au fur et
-				à mesure de votre propre sélection d’auteurs.</p>
-				<p>Ce message disparaîtra lorsque vous suivrez cinq auteurs. 
-				Rendez-vous ensuite  sur l’onglet « @auteurs » pour obtenir des suggestions d’auteurs.</p>',
+				à mesure de votre propre sélection d’auteur·es.</p>
+				<p>Ce message disparaîtra lorsque vous suivrez cinq auteur·es. 
+				Rendez-vous ensuite  sur l’onglet « @auteur·es » pour obtenir des suggestions d’auteur·es.</p>',
 	'modifier' => 'modifier',
 	'montrer_messages' => 'montrer les @total@ messages',
 
@@ -90,13 +90,13 @@ vous pouvez régler vos préférences dans votre profil
 
 	// P
 	'pave_accueil' => 'Du <strong>short-blogging</strong> sans limite de caractères. De la <strong>recommandation de liens</strong>. Des <strong>automatismes</strong> pour rédiger facilement vos messages. Des <strong>forums</strong> sous chaque billet. De la <strong>veille d’actualité</strong>. Une <strong>thématisation</strong> avancée.',
-	'people' => 'auteurs',
+	'people' => 'auteur·es',
 	'profil' => 'préférences',
 	'profil_alerte_conversations' => '<b>conversations</b> / quelqu’un répond à un billet auquel j’ai moi-même répondu',
 	'profil_alerte_dubien' => '<b>un ami qui vous veut du bien</b> / quelqu’un me suit',
 	'profil_alerte_mes_billets' => '<b>mes billets</b> / recevoir une copie de mes propres messages',
-	'profil_alerte_nolife' => '<b>nolife</b> / un auteur que je suis répond à n’importe quel billet',
-	'profil_alerte_nouveaux_billets' => '<b>nouveaux billets</b> / un nouveau billet est posté par un auteur que je suis',
+	'profil_alerte_nolife' => '<b>nolife</b> / un·e auteur·e que je suis répond à n’importe quel billet',
+	'profil_alerte_nouveaux_billets' => '<b>nouveaux billets</b> / un nouveau billet est posté par un·e auteur·e que je suis',
 	'profil_alerte_partage' => '<b>partage</b> / quelqu’un a partagé un de mes billets',
 	'profil_alerte_reponse_partage' => '<b>réponses à un partage</b> / quelqu’un répond à un billet que j’ai partagé',
 	'profil_alerte_reponses' => '<b>réponses à mes billets</b> / quelqu’un répond à un de mes billets',
@@ -113,7 +113,7 @@ vous pouvez régler vos préférences dans votre profil
 	'profil_licence' => 'Licence de vos messages',
 	'profil_liens_partage_fb' => 'Afficher les boutons de partage vers Facebook',
 	'profil_liens_partage_tw' => 'Afficher les boutons de partage vers Twitter',
-	'profil_logo' => 'Logo de l’auteur (carré)',
+	'profil_logo' => 'Logo de l’auteur·e (carré)',
 	'profil_mexpedier' => 'M’expédier un courrier<br /> électronique quand...',
 	'profil_partage' => 'Partage',
 	'profil_rss' => 'Importer automatiquement un flux d’articles au format ATOM ou RSS',
@@ -126,7 +126,7 @@ vous pouvez régler vos préférences dans votre profil
 
 	// S
 	'slogan_lien' => 'Inscrivez-vous, c’est gratuit et rapide !',
-	'slogan_texte' => '<strong>Participez à la discussion !</strong> Sur Seenthis, vous pouvez référencer des articles, les commenter, écrire des billets, discuter avec vos amis, suivre les auteurs qui vous intéressent...',
+	'slogan_texte' => '<strong>Participez à la discussion !</strong> Sur Seenthis, vous pouvez référencer des articles, les commenter, écrire des billets, discuter avec vos amis, suivre les auteur·es qui vous intéressent...',
 	'suggestions' => 'Suggestions :',
 	'suivre_people' => 'Suivre @people@',
 	'suivre_url' => 'Suivre ce site',
@@ -141,7 +141,7 @@ vous pouvez régler vos préférences dans votre profil
 	// T
 	'tags' => 'thèmes',
 	'theme_automatiquement' => 'Ce <b>thème</b> a été généré <b>automatiquement</b>.',
-	'theme_manuellement' => 'Ce <b>thème</b> est attribué <b>manuellement</b> par les auteurs des messages.',
+	'theme_manuellement' => 'Ce <b>thème</b> est attribué <b>manuellement</b> par les auteur·es des messages.',
 	'themes_automatiques' => 'thèmes automatiques',
 	'themes_vous_suivez' => 'Les thèmes que vous suivez',
 	'tous_les_messages_de' => 'Tous les messages de @people@',

--- a/lang/seenthis_fr.php
+++ b/lang/seenthis_fr.php
@@ -15,12 +15,12 @@ $GLOBALS[$GLOBALS['idx_lang']] = array(
 	'annuler' => 'Annuler',
 	'aucun_message' => 'Aucun message',
 	'auteur_block' => 'Bloquer @people@',
-	'auteur_block_you' => 'Cet auteur·e vous a bloqué. Vous ne pouvez pas commenter ses messages.',
+	'auteur_block_you' => 'Cet auteur vous a bloqué. Vous ne pouvez pas commenter ses messages.',
 	'auteur_ne_plus_block' => 'Débloquer @people@',
 	'auteur_ne_plus_suivre' => 'Ne plus suivre @people@',
 	'auteur_vous_block' => 'Vous avez bloqué @people@',
 	'auteur_vous_suivez' => 'Vous suivez @people@',
-	'auteurs_vous_suivez' => 'Les auteur·es que vous suivez',
+	'auteurs_vous_suivez' => 'Les auteurs que vous suivez',
 
 	// B
 	'beta_publique' => '<strong>Seenthis est en beta publique.</strong><br />Vous pouvez vous inscrire et participer, merci pour votre patience et votre bonne volonté durant cette phase.',
@@ -56,14 +56,14 @@ Vous pouvez le réactiver depuis votre page de préférences, en supprimant l’
 	'me_suggerer_contacts' => 'Me suggérer des contacts',
 	'message_inscription' => '<strong>Inscription gratuite et immédiate</strong><br />Dès l’enregistrement, votre mot de passe vous est expédié par email.',
 	'message_suggerer' => '
-				<strong>Nouveau sur Seenthis ? Vous devriez commencer par suivre des auteur·es.</strong>
+				<strong>Nouveau sur Seenthis ? Vous devriez commencer par suivre des auteurs.</strong>
 				<p>Cliquez sur le bouton « Me suggérer des contacts » ci-contre, et 
-				visitez les pages des auteur·es proposés. Si un auteur·e vous intéresse, suivez-le en cliquant, 
-				en haut de page, sur « Suivre cet auteur·e ».
+				visitez les pages des auteurs proposés. Si un auteur vous intéresse, suivez-le en cliquant, 
+				en haut de page, sur « Suivre cet auteur ».
 				Puis revenez sur cette page, recommencez l’opération, les propositions s’affineront au fur et
-				à mesure de votre propre sélection d’auteur·es.</p>
-				<p>Ce message disparaîtra lorsque vous suivrez cinq auteur·es. 
-				Rendez-vous ensuite  sur l’onglet « @auteur·es » pour obtenir des suggestions d’auteur·es.</p>',
+				à mesure de votre propre sélection d’auteurs.</p>
+				<p>Ce message disparaîtra lorsque vous suivrez cinq auteurs. 
+				Rendez-vous ensuite  sur l’onglet « @auteurs » pour obtenir des suggestions d’auteurs.</p>',
 	'modifier' => 'modifier',
 	'montrer_messages' => 'montrer les @total@ messages',
 
@@ -90,13 +90,13 @@ vous pouvez régler vos préférences dans votre profil
 
 	// P
 	'pave_accueil' => 'Du <strong>short-blogging</strong> sans limite de caractères. De la <strong>recommandation de liens</strong>. Des <strong>automatismes</strong> pour rédiger facilement vos messages. Des <strong>forums</strong> sous chaque billet. De la <strong>veille d’actualité</strong>. Une <strong>thématisation</strong> avancée.',
-	'people' => 'auteur·es',
+	'people' => 'auteurs',
 	'profil' => 'préférences',
 	'profil_alerte_conversations' => '<b>conversations</b> / quelqu’un répond à un billet auquel j’ai moi-même répondu',
 	'profil_alerte_dubien' => '<b>un ami qui vous veut du bien</b> / quelqu’un me suit',
 	'profil_alerte_mes_billets' => '<b>mes billets</b> / recevoir une copie de mes propres messages',
-	'profil_alerte_nolife' => '<b>nolife</b> / un·e auteur·e que je suis répond à n’importe quel billet',
-	'profil_alerte_nouveaux_billets' => '<b>nouveaux billets</b> / un nouveau billet est posté par un·e auteur·e que je suis',
+	'profil_alerte_nolife' => '<b>nolife</b> / un auteur que je suis répond à n’importe quel billet',
+	'profil_alerte_nouveaux_billets' => '<b>nouveaux billets</b> / un nouveau billet est posté par un auteur que je suis',
 	'profil_alerte_partage' => '<b>partage</b> / quelqu’un a partagé un de mes billets',
 	'profil_alerte_reponse_partage' => '<b>réponses à un partage</b> / quelqu’un répond à un billet que j’ai partagé',
 	'profil_alerte_reponses' => '<b>réponses à mes billets</b> / quelqu’un répond à un de mes billets',
@@ -113,7 +113,7 @@ vous pouvez régler vos préférences dans votre profil
 	'profil_licence' => 'Licence de vos messages',
 	'profil_liens_partage_fb' => 'Afficher les boutons de partage vers Facebook',
 	'profil_liens_partage_tw' => 'Afficher les boutons de partage vers Twitter',
-	'profil_logo' => 'Logo de l’auteur·e (carré)',
+	'profil_logo' => 'Logo de l’auteur (carré)',
 	'profil_mexpedier' => 'M’expédier un courrier<br /> électronique quand...',
 	'profil_partage' => 'Partage',
 	'profil_rss' => 'Importer automatiquement un flux d’articles au format ATOM ou RSS',
@@ -126,7 +126,7 @@ vous pouvez régler vos préférences dans votre profil
 
 	// S
 	'slogan_lien' => 'Inscrivez-vous, c’est gratuit et rapide !',
-	'slogan_texte' => '<strong>Participez à la discussion !</strong> Sur Seenthis, vous pouvez référencer des articles, les commenter, écrire des billets, discuter avec vos amis, suivre les auteur·es qui vous intéressent...',
+	'slogan_texte' => '<strong>Participez à la discussion !</strong> Sur Seenthis, vous pouvez référencer des articles, les commenter, écrire des billets, discuter avec vos amis, suivre les auteurs qui vous intéressent...',
 	'suggestions' => 'Suggestions :',
 	'suivre_people' => 'Suivre @people@',
 	'suivre_url' => 'Suivre ce site',
@@ -141,7 +141,7 @@ vous pouvez régler vos préférences dans votre profil
 	// T
 	'tags' => 'thèmes',
 	'theme_automatiquement' => 'Ce <b>thème</b> a été généré <b>automatiquement</b>.',
-	'theme_manuellement' => 'Ce <b>thème</b> est attribué <b>manuellement</b> par les auteur·es des messages.',
+	'theme_manuellement' => 'Ce <b>thème</b> est attribué <b>manuellement</b> par les auteurs des messages.',
 	'themes_automatiques' => 'thèmes automatiques',
 	'themes_vous_suivez' => 'Les thèmes que vous suivez',
 	'tous_les_messages_de' => 'Tous les messages de @people@',


### PR DESCRIPTION
Lorsque le nombre de commentaire d'un post dépasse 3, le fil des commentaires est replié à l'exception des 2 derniers et propose un lien _"montrer les n messages"_.
Mais une fois déplié il n'est plus possible de **replier** le fil des commentaires qui peut parfois être ultra-long obligeant un scroll de plusieurs kilomètres pour arriver au message suivant... (cf par ex les 350 commentaires de ce message: https://seenthis.net/messages/688734)
Ce PR ajoute un lien _"masquer les messages"_ pour donner la possibilité de replier le fil.

![seenthis_PR_afficher_message](https://user-images.githubusercontent.com/5904309/78669044-f0b84300-78db-11ea-9399-b65aa063cf2a.png)
