### PR TITLE
Moins de contenu des metas og/twitter:description

### DIFF
--- a/noisettes/head_message.html
+++ b/noisettes/head_message.html
@@ -19,7 +19,7 @@
 	</BOUCLE_auteur_metadata>
 
 	[(#SET{titre_metadonnee,#GET{texte_star}|extraire_titre{60}|attribut_html{false}})]
-	[(#SET{description_metadonnee, #GET{texte_star}|supprimer_titre{60, 256}|attribut_html{false}})]
+	[(#SET{description_metadonnee, #GET{texte_star}|supprimer_titre{60}|couper{256}|attribut_html{false}})]
 
 	[<meta name="og:title" content="(#GET{titre_metadonnee})"/>]
 	[<meta name="twitter:title" content="(#GET{titre_metadonnee})"/>]


### PR DESCRIPTION
Comme signalé ici https://seenthis.net/messages/844572 à ce jour on envoie le texte complet du message (sans le titre) dans ces metas, ce qui semble contre productif car twitter n'accepte que 200 caractères maxi.