### PR TITLE
afficher une mention dans le pied du message si celui-ci est issu d'un flux RSS

### DIFF
--- a/noisettes/message/afficher_un_message.html
+++ b/noisettes/message/afficher_un_message.html
@@ -42,7 +42,7 @@
 					href="#message#ID" rel="#ID_AUTEUR"></a>
 				</div>
 				
-				<span class="auteur">#GET{nom_auteur}</span>
+				<span class="auteur">#GET{nom_auteur}[(#VIARSS|oui)via RSS]</span>
 
 			</div>
 	


### PR DESCRIPTION
je laisse le texte en dur volontairement, pas certain que ça nécessite une traduction, à voir

ref https://github.com/seenthis/seenthis_squelettes/issues/177