### PR TITLE
cache à 0 pour le formulaire poster_message

### DIFF
--- a/formulaires/poster_message.html
+++ b/formulaires/poster_message.html
@@ -1,6 +1,6 @@
 #HTTP_HEADER{"Cache-Control: no-store, no-cache, must-revalidate"}
 #HTTP_HEADER{"Pragma: no-cache"}
-
+#CACHE{0}
 [<div id="poste(#ENV**{message_ok}|table_valeur{pave})" />]
 
 <div class="formulaire_spip formulaire_poster_message ajax">


### PR DESCRIPTION
pour palier au confilt entre le cache agressif de microcache et les jetons de sécu des formulaires introduits par SPIP 3.2.12

fix #275