### PR TITLE
réparer l'ajout du focus lors du chargement du formulaire de commentaire

### DIFF
--- a/javascript/seenthis/seenthis.js
+++ b/javascript/seenthis/seenthis.js
@@ -26,7 +26,9 @@ function switch_comments(id_me) {
 	if (!(message.is(':visible') && (message.height() > 10))) {
 		$('.formulaire_poster_message').removeClass('focus');
 		$('#yourmessage' + id_me).hide();
-		message.stop().slideDown("fast").find('.formulaire_poster_message').addClass('focus').find('textarea').show().focus();
+		setTimeout(function () {
+			message.stop().slideDown("fast").find('.formulaire_poster_message').addClass('focus').find('textarea').show().focus();
+		}, 500);
 	}
 }
 


### PR DESCRIPTION
en ajoutant un petit setTimeout() dans switch_comments(), c'est pas classe mais je n'ai pas trouvé mieux, et ça ne sera pas le premier dans le code seenthis :p

retour sur 177dd28 ref #275